### PR TITLE
draw from right to left

### DIFF
--- a/adv.py
+++ b/adv.py
@@ -1049,7 +1049,7 @@ class Board:
 
     def draw(self, win):
         for y, row in enumerate(self.B):
-            for x, cell in enumerate(row):
+            for x, cell in reversed([*enumerate(row)]):
                 # tricky bug: if an 'invisible' item put somewhere, then a being moves on top of it, it's drawn, but
                 # when it's moved out, the invisible item is drawn, but being an empty string, it doesn't draw over the
                 # being's char, so the 'image' of the being remains there, even after being moved away.


### PR DESCRIPTION
Draw the characters from right to left to fix misalignment issues on terminals where emojis are wide.

This helps to make sure that the characters are in the correct location, but a wide character may still overwrite the character right of it as can bee seen in these screenshots:

Old version:
![little_adventure_misaligned](https://user-images.githubusercontent.com/7968950/82241942-44876480-993d-11ea-8477-dbe3c5d31b69.png)

With this change:
![little_adventure_aligned](https://user-images.githubusercontent.com/7968950/82241889-36d1df00-993d-11ea-915e-40afde9f18bb.png)

My font does not know the emoji so unfortunately they still show up as black boxes, but that is just a problem on my end.

This worked fine when I tried to run it, but I did not test this expansively.

After the xy loop there are a few more draw commands. I don't know if they need to be changed.
If the characters in those commands can never be wide then it is not necessary to change them.